### PR TITLE
fix(deps): patch 2 critical and 13 high security alerts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,6 +82,8 @@ dependencies {
     implementation(SecurityFixes.springSecurityCore)
     implementation(SecurityFixes.springSecurityCrypto)
     implementation(SecurityFixes.jacksonDatabind)
+    implementation(SecurityFixes.jacksonCore)
+    implementation(SecurityFixes.jacksonAnnotations)
     implementation(SecurityFixes.handlebars)
 
     // ✅ Fijar versión estricta de junit-platform-commons para evitar conflictos

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,11 +74,15 @@ dependencies {
     implementation(SecurityFixes.nimbusJoseJwt)
     implementation(SecurityFixes.nettyCommon)
     implementation(SecurityFixes.nettyHandler)
+    implementation(SecurityFixes.nettyResolverDns)
+    implementation(SecurityFixes.nettyCodecHttp2)
     implementation(SecurityFixes.springWeb)
     implementation(SecurityFixes.springContext)
     implementation(SecurityFixes.springSecurityWeb)
     implementation(SecurityFixes.springSecurityCore)
     implementation(SecurityFixes.springSecurityCrypto)
+    implementation(SecurityFixes.jacksonDatabind)
+    implementation(SecurityFixes.handlebars)
 
     // ✅ Fijar versión estricta de junit-platform-commons para evitar conflictos
     add("implementation", Dependencies.Test.junitPlatformCommonsStrict)

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -71,12 +71,17 @@ object SecurityFixes {
 
     val nettyCommon = "io.netty:netty-common:${Versions.netty}"
     val nettyHandler = "io.netty:netty-handler:${Versions.netty}"
+    val nettyResolverDns = "io.netty:netty-resolver-dns:${Versions.netty}"
+    val nettyCodecHttp2 = "io.netty:netty-codec-http2:${Versions.netty}"
 
     val springWeb = "org.springframework:spring-web:${Versions.spring}"
     val springContext = "org.springframework:spring-context:${Versions.spring}"
     val springSecurityWeb = "org.springframework.security:spring-security-web:${Versions.springSecurity}"
     val springSecurityCore = "org.springframework.security:spring-security-core:${Versions.springSecurity}"
     val springSecurityCrypto = "org.springframework.security:spring-security-crypto:${Versions.springSecurity}"
+
+    val jacksonDatabind = "com.fasterxml.jackson.core:jackson-databind:${Versions.jacksonDatabind}"
+    val handlebars = "com.github.jknack:handlebars:${Versions.handlebars}"
 }
 
 /**

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -81,6 +81,8 @@ object SecurityFixes {
     val springSecurityCrypto = "org.springframework.security:spring-security-crypto:${Versions.springSecurity}"
 
     val jacksonDatabind = "com.fasterxml.jackson.core:jackson-databind:${Versions.jacksonDatabind}"
+    val jacksonCore = "com.fasterxml.jackson.core:jackson-core:${Versions.jacksonCore}"
+    val jacksonAnnotations = "com.fasterxml.jackson.core:jackson-annotations:${Versions.jacksonAnnotations}"
     val handlebars = "com.github.jknack:handlebars:${Versions.handlebars}"
 }
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -40,5 +40,7 @@ object Versions {
     const val spring = "6.1.15" // 🔐 updated to latest stable (matches Spring Boot 3.3.6)
     const val springSecurity = "6.3.5" // ⚠️ NOT bumped: CVE-2026-47838 (X.509 impersonation) fix for the 6.3.x line (6.3.18) is Enterprise-support-only, not published to Maven Central. Public OSS fix requires Spring Security 6.5.11, incompatible with this project's Spring Boot 3.3.6 / Spring Security 6.3.x baseline. See PR description.
     const val jacksonDatabind = "2.21.4" // 🔐 added to fix CVE-2026-54512 / CVE-2026-54513 (PolymorphicTypeValidator bypasses) + case-insensitive @JsonIgnoreProperties bypass + InetSocketAddress SSRF
+    const val jacksonCore = "2.21.4" // 🔐 kept in lockstep with jacksonDatabind: databind's ABI depends on a matching jackson-core release
+    const val jacksonAnnotations = "2.21" // 🔐 kept in lockstep with jacksonDatabind: mismatched jackson-annotations causes NoClassDefFoundError (JacksonAnnotationIntrospector references classes only present in matching annotations release; annotations has no patch component in its versioning)
     const val handlebars = "4.5.2" // 🔐 added to fix CVE-2026-55760 (FileTemplateLoader path traversal) - transitive via wiremock-jre8
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -25,7 +25,7 @@ object Versions {
 
     // 📝 Logging
     const val logstashLogback = "8.0" // Updated to latest stable
-    const val logback = "1.5.20" // 🔐 updated to latest stable version
+    const val logback = "1.5.33" // 🔐 updated to fix CVE-2026-9828 (HardenedObjectInputStream allowlist bypass)
 
     // 🔐 Security-related fixes (updated for CVE mitigation)
     const val commonsBeanutils = "1.9.4"
@@ -34,9 +34,11 @@ object Versions {
     const val artemis = "2.35.0" // 🔐 updated to latest stable
     const val jetty = "11.0.21" // 🔐 updated to latest stable (11.x compatible with Spring Boot 3.3)
     const val xmlunit = "2.10.0" // Updated to latest
-    const val bcprov = "1.82" // 🔐 updated to latest stable for security
+    const val bcprov = "1.84" // 🔐 updated to fix CVE-2025-14813 (GOST28147 CTR keystream reuse) + covert timing channel
     const val nimbusJoseJwt = "9.40" // 🔐 updated to latest stable (10.5 is major version, needs compatibility check)
-    const val netty = "4.1.115.Final" // 🔐 updated to match Spring Boot 3.3.6 default version
+    const val netty = "4.1.135.Final" // 🔐 updated to fix multiple CVEs (hostname verification bypass, SNI, DNS cache poisoning, HTTP/2 DoS)
     const val spring = "6.1.15" // 🔐 updated to latest stable (matches Spring Boot 3.3.6)
-    const val springSecurity = "6.3.5" // 🔐 updated to latest stable (matches Spring Boot 3.3.6)
+    const val springSecurity = "6.3.5" // ⚠️ NOT bumped: CVE-2026-47838 (X.509 impersonation) fix for the 6.3.x line (6.3.18) is Enterprise-support-only, not published to Maven Central. Public OSS fix requires Spring Security 6.5.11, incompatible with this project's Spring Boot 3.3.6 / Spring Security 6.3.x baseline. See PR description.
+    const val jacksonDatabind = "2.21.4" // 🔐 added to fix CVE-2026-54512 / CVE-2026-54513 (PolymorphicTypeValidator bypasses) + case-insensitive @JsonIgnoreProperties bypass + InetSocketAddress SSRF
+    const val handlebars = "4.5.2" // 🔐 added to fix CVE-2026-55760 (FileTemplateLoader path traversal) - transitive via wiremock-jre8
 }

--- a/constraints.gradle.kts
+++ b/constraints.gradle.kts
@@ -3,6 +3,9 @@ dependencies {
         // 🔐 Spring Framework / Security (DoS, Auth Bypass, Password length)
         // Updated to latest stable versions compatible with Spring Boot 3.3.6
         // Note: Spring Boot 3.3.6 manages these versions, but we force them for security
+        // ⚠️ spring-security-web NOT bumped for CVE-2026-47838 (X.509 impersonation): the OSS fix for the
+        // 6.3.x line (6.3.18) is Enterprise-support-only; public fix requires 6.5.11, which needs a
+        // Spring Boot minor version upgrade. See PR description for details.
         implementation("org.springframework:spring-web:6.1.15")
         implementation("org.springframework:spring-context:6.1.15")
         implementation("org.springframework.security:spring-security-web:6.3.5")
@@ -17,22 +20,31 @@ dependencies {
         implementation("org.eclipse.jetty:jetty-io:11.0.21")
 
         // ⚡ Netty (WebFlux internals, DoS vuln)
-        // Updated to match Spring Boot 3.3.6 default version (4.1.115.Final)
-        implementation("io.netty:netty-common:4.1.115.Final")
-        implementation("io.netty:netty-handler:4.1.115.Final")
+        // 🔐 Updated to fix CVE-2026-44249 (IPv6 subnet-filter bypass), CVE-2026-47691 (DNS cache poisoning),
+        // CVE-2026-50560 (HTTP/2 DoS), CVE-2026-50010 (TLS hostname verification bypass) and others
+        implementation("io.netty:netty-common:4.1.135.Final")
+        implementation("io.netty:netty-handler:4.1.135.Final")
+        implementation("io.netty:netty-resolver-dns:4.1.135.Final")
+        implementation("io.netty:netty-codec-http2:4.1.135.Final")
 
         // 🔐 Nimbus JOSE JWT (DoS via parsing)
         // Updated to latest stable version
         implementation("com.nimbusds:nimbus-jose-jwt:9.40")
 
         // ⚠️ Logback-core (EL Injection + CSRF via config)
-        // Updated to latest stable version
-        implementation("ch.qos.logback:logback-core:1.5.20")
-        implementation("ch.qos.logback:logback-classic:1.5.20")
+        // 🔐 Updated to fix CVE-2026-9828 (HardenedObjectInputStream allowlist bypass)
+        implementation("ch.qos.logback:logback-core:1.5.33")
+        implementation("ch.qos.logback:logback-classic:1.5.33")
 
         // 🔒 Bouncy Castle (Marvin attack, DNS poisoning, Infinite loop, CPU usage)
-        // Updated to latest stable version
-        implementation("org.bouncycastle:bcprov-jdk18on:1.82")
+        // 🔐 Updated to fix CVE-2025-14813 (GOST28147 CTR keystream reuse after 255 blocks) + covert timing channel
+        implementation("org.bouncycastle:bcprov-jdk18on:1.84")
+
+        // 🔐 Jackson-databind (PolymorphicTypeValidator bypasses, SSRF, @JsonIgnoreProperties bypass)
+        implementation("com.fasterxml.jackson.core:jackson-databind:2.21.4")
+
+        // 🔐 Handlebars (transitive via wiremock-jre8) - FileTemplateLoader Path Traversal
+        implementation("com.github.jknack:handlebars:4.5.2")
 
         // ⚠️ Apache Commons
         implementation("commons-beanutils:commons-beanutils:1.9.4")

--- a/constraints.gradle.kts
+++ b/constraints.gradle.kts
@@ -41,7 +41,11 @@ dependencies {
         implementation("org.bouncycastle:bcprov-jdk18on:1.84")
 
         // 🔐 Jackson-databind (PolymorphicTypeValidator bypasses, SSRF, @JsonIgnoreProperties bypass)
+        // Kept in lockstep with jackson-core/jackson-annotations: bumping databind alone causes
+        // NoClassDefFoundError at runtime (mismatched jackson-annotations classes).
         implementation("com.fasterxml.jackson.core:jackson-databind:2.21.4")
+        implementation("com.fasterxml.jackson.core:jackson-core:2.21.4")
+        implementation("com.fasterxml.jackson.core:jackson-annotations:2.21")
 
         // 🔐 Handlebars (transitive via wiremock-jre8) - FileTemplateLoader Path Traversal
         implementation("com.github.jknack:handlebars:4.5.2")

--- a/package-lock.json
+++ b/package-lock.json
@@ -2434,9 +2434,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3005,16 +3005,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/p-limit": {
@@ -3996,16 +3986,13 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -2,5 +2,8 @@
   "devDependencies": {
     "@release-it/conventional-changelog": "^8.0.1",
     "release-it": "^19.0.6"
+  },
+  "overrides": {
+    "tmp": "^0.2.7"
   }
 }


### PR DESCRIPTION
## Summary

Patches the Dependabot alerts explicitly targeted for this pass (2 critical, 13 high, 2 medium). This repo's `security/dependabot` tab currently shows 85 total alerts (5 critical / 36 high / 34 moderate / 10 low) — the remainder are out of scope for this PR and left for a follow-up.

Version source of truth for this project is `buildSrc/src/main/kotlin/Versions.kt` (referenced from `build.gradle.kts` via the `Dependencies`/`SecurityFixes` objects), **not** `settings.gradle.kts` or a `libs.versions.toml` (neither exists). There is also an orphaned `constraints.gradle.kts` at the repo root with hardcoded, duplicate version strings for several of these same packages — it is not `apply(from = ...)`'d anywhere so it has **no effect on the actual build**, but Dependabot's manifest scanner still parses it, which is the likely cause of the duplicate alert pairs mentioned below. I kept it in sync rather than removing it (removing/wiring it in is a build-behavior change I didn't want to make without being able to run a build).

## Gradle dependency bumps

| Package | Old | New | Fixes |
|---|---|---|---|
| `org.bouncycastle:bcprov-jdk18on` | 1.82 | **1.84** | CVE-2025-14813 — GOST 28147 CTR mode reuses keystream after 255 blocks (critical); also fixes a covert timing channel (high) |
| `io.netty:netty-common`, `netty-handler` | 4.1.115.Final | **4.1.135.Final** | CVE-2026-44249 (IPv6 subnet-filter bypass), CVE-2026-50010 (TLS hostname verification bypass), SNI 16MiB pre-allocation, CVE-2026-47691 (DNS cache poisoning), NS-record Bailiwick validation, CVE-2026-50560 (HTTP/2 decompression-bomb DoS), plus several medium issues (HTTP/2 Reset Attack, ByteBuf ref-count leak, MAX_CONCURRENT_STREAMS enforcement, DNS PRNG predictability, unix-socket fd leaks) |
| `io.netty:netty-resolver-dns`, `netty-codec-http2` | *(transitive, unpinned — inherited an old version from the Spring Boot BOM)* | **4.1.135.Final** (new explicit forces) | Same Netty CVEs above — these two artifacts were flagged by Dependabot but weren't previously force-pinned like `netty-common`/`netty-handler`, so I added explicit `SecurityFixes` entries for them too, using the same shared `Versions.netty` constant |
| `com.fasterxml.jackson.core:jackson-databind` | *(transitive, unpinned — inherited from the Spring Boot BOM)* | **2.21.4** (new explicit force) | CVE-2026-54512 / CVE-2026-54513 — two `PolymorphicTypeValidator` bypasses (generic-type parameters, array-subtype allowlist), each surfaced as a duplicate alert pair; also fixes case-insensitive `@JsonIgnoreProperties` bypass and `InetSocketAddress` eager DNS resolution SSRF (both medium) |
| `com.github.jknack:handlebars` | *(transitive via `wiremock-jre8`, unpinned)* | **4.5.2** (new explicit force) | CVE-2026-55760 — `FileTemplateLoader` path traversal |
| `ch.qos.logback:logback-core`, `logback-classic` | 1.5.20 | **1.5.33** | CVE-2026-9828 — `HardenedObjectInputStream` allowlist bypass (object injection, low severity). Cheap one-line bump within the 1.5.x line, done alongside the others. |

### `org.springframework.security:spring-security-web` — NOT bumped, needs a follow-up

Checked GitHub Security Advisories before touching this one. The alert is CVE-2026-47838 ("Unauthorized User Impersonation when Using X.509 Client Certificates"). This project pins Spring Security **6.3.5**, which falls in the affected range (6.3.0–6.3.17). The catch: the public/OSS-published fix for the 6.3.x line is **6.3.18, and it's Enterprise-support-only** (not on Maven Central). The only publicly available fixed release is **6.5.11**, which is two minor versions ahead and is the version aligned with Spring Boot 3.5.x, not this project's Spring Boot 3.3.6.

Force-bumping just `spring-security-web` to 6.5.11 while `spring-security-core`/`-config`/`-crypto` and Spring Boot itself stay on the 3.3.6/6.3.x baseline risks module version skew I can't validate without a build. Fixing this properly needs a coordinated Spring Boot minor-version upgrade (3.3.6 → 3.4.x/3.5.x), which is a bigger, separate change. Recommend opening a dedicated follow-up for that upgrade.

## npm bumps (`package.json` / `package-lock.json`)

| Package | Old | New | Fixes |
|---|---|---|---|
| `tmp` | 0.0.33 | **0.2.7** (not 0.2.6) | CVE-2026-44705 — path traversal via unsanitized `prefix`/`postfix`. Went with 0.2.7 instead of the requested 0.2.6 because 0.2.6's own `_assertPath` guard was itself bypassable via non-string `prefix`/`postfix`/`template` (CVE-2026-49982, fixed in 0.2.7) — no reason to ship a version with a known follow-up bypass. `tmp` is a transitive dep of `external-editor` (pulled in by `release-it`'s `inquirer`), which requires `tmp@^0.0.33` — incompatible with 0.2.x by semver, so I added a `package.json` `overrides` entry to force it. |
| `js-yaml` | 4.1.0 | **4.2.0** | CVE-2026-53550 — quadratic-complexity DoS in merge-key handling via repeated aliases. Transitive via `cosmiconfig` (used by `@release-it/conventional-changelog`), whose declared range `^4.1.0` already permits 4.2.0, so no override was needed — just bumped the resolved version in the lockfile. |
| npm `handlebars` (4.7.8) | — | — | Not touched. This is the unrelated npm `handlebars` package (already at latest, no active CVE) — different from the Java `com.github.jknack:handlebars` flagged in the Gradle alert. |

### Note: `npm ci` already fails on `main`, independent of this PR

While validating the npm changes I found that `npm ci` fails on the **current, unmodified `main` branch** — `package.json` declares `release-it: ^19.0.6` but `package-lock.json` is still resolved against `release-it@17.11.0`, producing dozens of `Invalid`/`Missing` errors (`chalk`, `execa`, `string-width`, etc.). This is pre-existing lockfile/manifest drift, unrelated to any of these CVEs, and I deliberately did **not** run a full `npm install` to "fix" it in this PR — doing so cascades a ~3,000-line unrelated dependency resync (verified in an isolated test) that would bury the actual security diff and constitutes an unreviewed major-version tooling upgrade. I hand-edited just the `tmp`/`js-yaml`/`os-tmpdir` lockfile entries to keep this PR's npm diff minimal and reviewable. Recommend a separate PR to regenerate `package-lock.json` for `release-it`.

## Left unfixed (flagged, not fixed here)

- **`org.springframework.security:spring-security-web`** — see above, needs a Spring Boot minor bump.
- **`release-it` / npm lockfile drift** — pre-existing on `main`, `npm ci` currently fails; unrelated to these CVEs, needs its own PR.
- 70 other Dependabot alerts on the default branch not covered by this task's target list.
